### PR TITLE
added constants for MacOS 26

### DIFF
--- a/IntelMKLFixup/IntelMKLFixup.cpp
+++ b/IntelMKLFixup/IntelMKLFixup.cpp
@@ -97,7 +97,7 @@ PluginConfiguration ADDPR(config) {
 	bootargBeta,
 	arrsize(bootargBeta),
 	KernelVersion::HighSierra,
-	KernelVersion::Sequoia,
+	KernelVersion::Tahoe,
 	[]() {
 		DBGLOG(MODULE_SHORT, "Intel(tm) Math Kernel Library fixup plugin loaded");
 		


### PR DESCRIPTION
Just changed kernel version so this kext runs on MacOS 26 Tahoe. 